### PR TITLE
Making address on timer_idx() to get only timer address space

### DIFF
--- a/rtl/verilog/ahb3lite_timer.sv
+++ b/rtl/verilog/ahb3lite_timer.sv
@@ -243,6 +243,7 @@ module ahb3lite_timer #(
                            offset;   //offset in HADDR space
 
     timer_idx = address - offset;    //remove offset
+    timer_idx = timer_idx && 'hFF;   //masking to remove upper bits and get only timer address space
     timer_idx >>= 4;                 //MSBs determine index
   endfunction : timer_idx
 


### PR DESCRIPTION
The function would not return the correct index on my simulations. This was happening because the timer_idx function does not take into consideration that the timer base address can be different from 0x0. For example, if the base address is `32'h4000_0400`, the operation `address - offset` for timer 0 will return `'h4000_0418 - 'h18 = 'h4000_0400`, which cannot be converted to an index. A masking must be done to select only the address space allowed by the number of timers (32). After the masking, the function works as expected.

- 31 * 8 = hf8 = b1111_1000 (maximum base address for the 32nd register after removing the offset)
- max offset on the top (63:32) -> hff = b1111_1111
- That means that it should be masked with b1111_1111 = hFF
